### PR TITLE
Traefik configuration for the server

### DIFF
--- a/.github/workflows/server-helm-chart.yml
+++ b/.github/workflows/server-helm-chart.yml
@@ -38,3 +38,10 @@ jobs:
             -summary -strict \
             -schema-location default \
             -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
+
+          # Check the API Gateway resources
+          helm template . --set global.fqdn=test.local --set hubAPI.enable=true --set coco.replicas=3 --set saline.enable=true \
+               --set gateway.enable=true --set gateway.class=gw | \
+           kubeconform -summary -strict \
+             -schema-location default \
+             -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'

--- a/containers/proxy-helm/proxy-helm.changes.cbosdo.server-selinux
+++ b/containers/proxy-helm/proxy-helm.changes.cbosdo.server-selinux
@@ -1,0 +1,1 @@
+- Allow configuring the ingress class on the traefik routes

--- a/containers/proxy-helm/templates/traefik-routes.yaml
+++ b/containers/proxy-helm/templates/traefik-routes.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: proxy
     app.kubernetes.io/part-of: uyuni
   annotations:
-    kubernetes.io/ingress.class: traefik
+    kubernetes.io/ingress.class: {{ .Values.ingress.class }}
 spec:
   entryPoints:
     - ssh 
@@ -27,7 +27,7 @@ metadata:
     app.kubernetes.io/component: proxy
     app.kubernetes.io/part-of: uyuni
   annotations:
-    kubernetes.io/ingress.class: traefik
+    kubernetes.io/ingress.class: {{ .Values.ingress.class }}
 spec:
   entryPoints:
     - salt-publish
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/component: proxy
     app.kubernetes.io/part-of: uyuni
   annotations:
-    kubernetes.io/ingress.class: traefik
+    kubernetes.io/ingress.class: {{ .Values.ingress.class }}
 spec:
   entryPoints:
     - salt-request

--- a/containers/proxy-helm/tests/README.md
+++ b/containers/proxy-helm/tests/README.md
@@ -1,0 +1,2 @@
+The unit tests in this folder are written using helm-unittest.
+See https://github.com/helm-unittest/helm-unittest/blob/main/DOCUMENT.md for its reference.

--- a/containers/proxy-helm/tests/nginx_test.yaml
+++ b/containers/proxy-helm/tests/nginx_test.yaml
@@ -1,7 +1,7 @@
 suite: test global values parsing
 templates:
   - templates/ingress.yaml
-  - templates/k3s-ingress-routes.yaml
+  - templates/traefik-routes.yaml
 tests:
   - it: should configure the ingress for nginx
     set:
@@ -27,4 +27,4 @@ tests:
 
       - hasDocuments:
           count: 0
-        template: k3s-ingress-routes.yaml
+        template: traefik-routes.yaml

--- a/containers/proxy-helm/tests/traefik_test.yaml
+++ b/containers/proxy-helm/tests/traefik_test.yaml
@@ -1,7 +1,7 @@
 suite: test global values parsing
 templates:
   - templates/ingress.yaml
-  - templates/k3s-ingress-routes.yaml
+  - templates/traefik-routes.yaml
 tests:
   - it: should create traefik resources
     set:
@@ -46,7 +46,7 @@ tests:
 
       - hasDocuments:
           count: 3
-        template: k3s-ingress-routes.yaml
+        template: traefik-routes.yaml
 
       # SSH router checks
       - contains:
@@ -54,7 +54,7 @@ tests:
           content:
             name: ssh
             port: 8022
-        template: k3s-ingress-routes.yaml
+        template: traefik-routes.yaml
         documentSelector:
           path: metadata.name
           value: ssh-router
@@ -64,7 +64,7 @@ tests:
           apiVersion: traefik.io/v1alpha1
           namespace: proxy1
           name: ssh-router
-        template: k3s-ingress-routes.yaml
+        template: traefik-routes.yaml
         documentSelector:
           path: metadata.name
           value: ssh-router
@@ -76,7 +76,7 @@ tests:
             name: salt
             port: 4505
           any: true
-        template: k3s-ingress-routes.yaml
+        template: traefik-routes.yaml
         documentSelector:
           path: metadata.name
           value: salt-publish-router
@@ -86,7 +86,7 @@ tests:
           apiVersion: traefik.io/v1alpha1
           namespace: proxy1
           name: salt-publish-router
-        template: k3s-ingress-routes.yaml
+        template: traefik-routes.yaml
         documentSelector:
           path: metadata.name
           value: salt-publish-router
@@ -98,7 +98,7 @@ tests:
             name: salt
             port: 4506
           any: true
-        template: k3s-ingress-routes.yaml
+        template: traefik-routes.yaml
         documentSelector:
           path: metadata.name
           value: salt-request-router
@@ -108,7 +108,7 @@ tests:
           apiVersion: traefik.io/v1alpha1
           namespace: proxy1
           name: salt-request-router
-        template: k3s-ingress-routes.yaml
+        template: traefik-routes.yaml
         documentSelector:
           path: metadata.name
           value: salt-request-router

--- a/containers/proxy-helm/values.yaml
+++ b/containers/proxy-helm/values.yaml
@@ -36,6 +36,9 @@ ingress:
   type: "traefik"
   
   ## Specify the ingress class name to use. Empty, means that the default one will be used.
+  ## If using the traefik end points and TCP routers, this value needs to match Traefik's
+  ## --providers.kubernetescrd.ingressclass parameter's value.
+  ## On rke2 this is likely to be "traefik". On K3S it is likely to be ""
   ##
   class: ""
   

--- a/containers/server-helm/README.md
+++ b/containers/server-helm/README.md
@@ -74,10 +74,7 @@ Here is a list of the ports to map:
 | TCP      | 4506  | salt         | 4506         |                                                  |
 | TCP      | 25151 | cobbler      | 25151        |                                                  |
 | TCP      | 9100  | tomcat       | 9100         |                                                  |
-| TCP      | 5556  | taskomatic   | 5556         | Not if installed with `enableMonitoring = false` |
-| TCP      | 5557  | tomcat       | 5557         | Not if installed with `enableMonitoring = false` |
 | TCP      | 9187  | db           | 9187         | Not if installed with `enableMonitoring = false` |
-| TCP      | 9800  | taskomatic   | 9800         | Not if installed with `enableMonitoring = false` |
 | TCP      | 8001  | taskomatic   | 8001         | Only if installed with `exposeJavaDebug = true`  |
 | TCP      | 8002  | search       | 8002         | Only if installed with `exposeJavaDebug = true`  |
 | TCP      | 8003  | tomcat       | 8003         | Only if installed with `exposeJavaDebug = true`  |
@@ -86,6 +83,18 @@ Here is a list of the ports to map:
 Exposing the `tftp` service has to be done differently due to the way TFTP protocol is working.
 Either use the host network using the `tftp.hostnetwork` value or configure a load balancer for the `tftp` service.
 Note that not all load balancers will work: `serviceLB` implementation is not compatible with TFTP protocol, while MetalLB works.
+
+### Ingress vs Gateway API
+
+The helm chart deploys ingress rules by default.
+Switching to [Gateway API](https://gateway-api.sigs.k8s.io/) instead is possible though requires more effort.
+The Gateway API implementation used in this helm chart is aligned with the one handled by the traefik shipped with the latest RKE2.
+
+Using the Gateway API routes is still experimental as some of the needed resources, namely `TCPRoute` are not stable yet.
+To enable it, set the `gateway.enable` value.
+The other values in the `gateway` structure may need to be set depending on the cluster setup.
+
+**Note that on RKE2 1.35 on top of enabling Traefik with Gateway API, the `TLSRoute` and `TCPRoute` CRDs need to be manually added and the Traefik helm chart has to be deployed with the `providers.kubernetesGateway.experimentalChannel`.**
 
 ## Usage
 

--- a/containers/server-helm/server-helm.changes.cbosdo.server-selinux
+++ b/containers/server-helm/server-helm.changes.cbosdo.server-selinux
@@ -1,1 +1,2 @@
+- Route the exporters over HTTP using ingress rules
 - Separate the cgroup mount from the host one

--- a/containers/server-helm/templates/gateway.yaml
+++ b/containers/server-helm/templates/gateway.yaml
@@ -1,0 +1,78 @@
+{{- if and .Values.gateway.enable (ne .Values.gateway.name "") }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: uyuni-gateway
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    app.kubernetes.io/part-of: uyuni
+spec:
+  gatewayClassName: "{{ .Values.gateway.class }}"
+  listeners:
+    # HTTP/HTTPS Listeners
+    - name: {{ default .Values.gateway.listeners.http.name "web" }}
+      protocol: HTTP
+      port: {{ default .Values.gateway.listeners.http.port 8000 }}
+      allowedRoutes:
+        namespaces:
+          from: Same
+    
+    - name: {{ default .Values.gateway.listeners.http.name "websecure" }}
+      protocol: HTTPS
+      port: {{ default .Values.gateway.listeners.https.port 8443 }}
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: uyuni-cert
+      allowedRoutes:
+        namespaces:
+          from: Same
+
+    # TCP Listeners
+    - name: salt-publish
+      protocol: TCP
+      port: 4505
+      allowedRoutes:
+        namespaces:
+          from: Same
+
+    - name: salt-request
+      protocol: TCP
+      port: 4506
+      allowedRoutes:
+        namespaces:
+          from: Same
+
+    {{- if .Values.db.enable }}
+    - name: reportdb-pgsql
+      protocol: TCP
+      port: 5432
+      allowedRoutes:
+        namespaces:
+          from: Same
+    {{- end }}
+
+    # Debug TCP Listeners
+    {{- if .Values.exposeJavaDebug }}
+    - name: tasko-debug
+      protocol: TCP
+      port: 8001
+      allowedRoutes:
+        namespaces:
+          from: Same
+
+    - name: search-debug
+      protocol: TCP
+      port: 8002
+      allowedRoutes:
+        namespaces:
+          from: Same
+
+    - name: tomcat-debug
+      protocol: TCP
+      port: 8003
+      allowedRoutes:
+        namespaces:
+          from: Same
+    {{- end }}
+{{- end }}

--- a/containers/server-helm/templates/ingress.yaml
+++ b/containers/server-helm/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.gateway.enable }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -8,7 +9,9 @@ metadata:
   {{- if eq ((.Values.ingress).type) "traefik" }}
     traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/router.tls.domains.n.main: "{{ required "global.fqdn is needed!" .Values.global.fqdn }}"
-    traefik.ingress.kubernetes.io/router.entrypoints: "websecure,web"
+    traefik.ingress.kubernetes.io/router.entrypoints: "websecure"
+    traefik.ingress.kubernetes.io/router.priority: "1"
+    traefik.ingress.kubernetes.io/router.middlewares: "{{ .Release.Namespace }}-uyuni-strip-prefixes@kubernetescrd"
   {{- end }}
   {{- if (((.Values.ingress).annotations).ssl) }}
 {{ toYaml .Values.ingress.annotations.ssl | indent 4 }}
@@ -28,20 +31,95 @@ spec:
   - host: {{ required "global.fqdn is needed!" .Values.global.fqdn }}
     http:
       paths:
-      - backend:
+      - path: /
+        backend:
           service:
             name: web 
             port:
               number: 80
-        path: /
         pathType: Prefix
-  {{- if default .Values.hubAPI.enable false }}
+  {{- if .Values.saline.enable }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  creationTimestamp: null
+  name: saline-ingress-ssl
+  namespace: "{{ .Release.Namespace }}"
+  annotations:
+  {{- if eq ((.Values.ingress).type) "traefik" }}
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/router.tls.domains.n.main: "{{ required "global.fqdn is needed!" .Values.global.fqdn }}"
+    traefik.ingress.kubernetes.io/router.entrypoints: "websecure"
+    traefik.ingress.kubernetes.io/router.priority: "100"
+    traefik.ingress.kubernetes.io/router.middlewares: "{{ .Release.Namespace }}-uyuni-strip-prefixes@kubernetescrd"
+  {{- end }}
+  {{- if (((.Values.ingress).annotations).saline) }}
+{{ toYaml .Values.ingress.annotations.saline | indent 4 }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/part-of: uyuni
+    app.kubernetes.io/component: saline
+spec:
+  {{- if ((.Values.ingress).class) }}
+  ingressClassName: {{ .Values.ingress.class }}
+  {{- end }}
+  tls:
+    - hosts:
+      - {{ required "global.fqdn is needed!" .Values.global.fqdn }}
+      secretName: uyuni-cert
+  rules:
+  - host: {{ required "global.fqdn is needed!" .Values.global.fqdn }}
+    http:
+      paths:
       - backend:
+          service:
+            name: saline
+            port:
+              number: 8216
+        path: /saline
+        pathType: Prefix
+  {{- end }}
+  {{- if default .Values.hubAPI.enable false }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  creationTimestamp: null
+  name: hubapi-ingress-ssl
+  namespace: "{{ .Release.Namespace }}"
+  annotations:
+  {{- if eq ((.Values.ingress).type) "traefik" }}
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/router.tls.domains.n.main: "{{ required "global.fqdn is needed!" .Values.global.fqdn }}"
+    traefik.ingress.kubernetes.io/router.entrypoints: "websecure"
+    traefik.ingress.kubernetes.io/router.priority: "100"
+    traefik.ingress.kubernetes.io/router.middlewares: "{{ .Release.Namespace }}-uyuni-strip-prefixes@kubernetescrd"
+  {{- end }}
+  {{- if (((.Values.ingress).annotations).hub) }}
+{{ toYaml .Values.ingress.annotations.hub | indent 4 }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/part-of: uyuni
+    app.kubernetes.io/component: hub-xmlrpc
+spec:
+  {{- if ((.Values.ingress).class) }}
+  ingressClassName: {{ .Values.ingress.class }}
+  {{- end }}
+  tls:
+    - hosts:
+      - {{ required "global.fqdn is needed!" .Values.global.fqdn }}
+      secretName: uyuni-cert
+  rules:
+  - host: {{ required "global.fqdn is needed!" .Values.global.fqdn }}
+    http:
+      paths:
+      - path: /hub/rpc/api
+        backend:
           service:
             name: hub-xmlrpc
             port:
               number: 2830
-        path: /hub/rpc/api
         pathType: Prefix
   {{- end }}
   {{- if eq ((.Values.ingress).type) "traefik" }}
@@ -53,8 +131,9 @@ metadata:
   name: uyuni-ingress-ssl-redirect
   namespace: "{{ .Release.Namespace }}"
   annotations:
-    traefik.ingress.kubernetes.io/router.middlewares: "default-uyuni-https-redirect@kubernetescrd"
+    traefik.ingress.kubernetes.io/router.middlewares: "{{ .Release.Namespace }}-uyuni-https-redirect@kubernetescrd"
     traefik.ingress.kubernetes.io/router.entrypoints: "web"
+    traefik.ingress.kubernetes.io/router.priority: "1"
   {{- if (((.Values.ingress).annotations).sslRedirect) }}
 {{ toYaml .Values.ingress.annotations.sslRedirect | indent 4 }}
   {{- end }}
@@ -71,7 +150,7 @@ spec:
       paths:
       - backend:
           service:
-            name: web 
+            name: web
             port:
               number: 80
         path: /
@@ -94,11 +173,11 @@ metadata:
   name: uyuni-ingress-nossl
   namespace: "{{ .Release.Namespace }}"
   annotations:
-  {{- if eq ((.Values.ingress).type) "nginx" }}
-    nginx.ingress.kubernetes.io/ssl-redirect: "false"
-  {{- else if eq ((.Values.ingress).type) "traefik" }}
+  {{- if eq ((.Values.ingress).type) "traefik" }}
     traefik.ingress.kubernetes.io/router.tls: "false"
     traefik.ingress.kubernetes.io/router.entrypoints: "web"
+    traefik.ingress.kubernetes.io/router.priority: "100"
+    traefik.ingress.kubernetes.io/router.middlewares: "{{ .Release.Namespace }}-uyuni-strip-prefixes@kubernetescrd"
   {{- end }}
   {{- if (((.Values.ingress).annotations).nossl) }}
 {{ toYaml .Values.ingress.annotations.nossl | indent 4 }}
@@ -233,3 +312,43 @@ spec:
               number: 80
         path: /docs
         pathType: Prefix
+  {{- if ne .Values.enableMonitoring false }}
+      - path: /node-exporter
+        backend:
+          service:
+            name: tomcat
+            port:
+              number: 9100
+        pathType: Prefix
+      - path: /tasko-exporter
+        backend:
+          service:
+            name: taskomatic
+            port:
+              number: 9800
+        pathType: Prefix
+      - path: /tasko-jmx
+        backend:
+          service:
+            name: taskomatic
+            port:
+              number: 5556
+        pathType: Prefix
+      - path: /tomcat-jmx
+        backend:
+          service:
+            name: tomcat
+            port:
+              number: 5557
+        pathType: Prefix
+  {{- end }}
+  {{- if .Values.saline.enable }}
+      - backend:
+          service:
+            name: saline
+            port:
+              number: 8216
+        path: /saline
+        pathType: Prefix
+  {{- end }}
+  {{- end }}

--- a/containers/server-helm/templates/routes.yaml
+++ b/containers/server-helm/templates/routes.yaml
@@ -1,0 +1,159 @@
+{{- if .Values.gateway.enable }}
+{{- $fqdn := required "global.fqdn is needed!" .Values.global.fqdn -}}
+{{- $gatewayName := default .Values.gateway.name "uyuni-gateway" -}}
+
+# SSL Redirection (Port 80 to 443)
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: uyuni-ssl-redirect
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    app.kubernetes.io/part-of: uyuni
+spec:
+  parentRefs:
+    - name: {{ $gatewayName }}
+      sectionName: web
+  hostnames:
+    - {{ $fqdn | quote }}
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+---
+# HTTPS Routes
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: uyuni-https-routes
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    app.kubernetes.io/part-of: uyuni
+spec:
+  parentRefs:
+    - name: {{ $gatewayName }}
+      sectionName: websecure
+  hostnames:
+    - {{ $fqdn | quote }}
+  rules:
+    {{- if .Values.saline.enable }}
+    - matches:
+        - path: { type: PathPrefix, value: /saline }
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path: { type: ReplacePrefixMatch, replacePrefixMatch: / }
+      backendRefs:
+        - name: saline
+          port: 8216
+    {{- end }}
+    {{- if default .Values.hubAPI.enable false }}
+    - matches:
+        - path: { type: PathPrefix, value: /hub/rpc/api }
+      backendRefs:
+        - name: hub-xmlrpc
+          port: 2830
+    {{- end }}
+    - matches:
+        - path: { type: PathPrefix, value: / }
+      backendRefs:
+        - name: web
+          port: 80
+---
+# Non-SSL Paths
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: uyuni-nossl-routes
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    app.kubernetes.io/part-of: uyuni
+spec:
+  parentRefs:
+    - name: {{ $gatewayName }}
+      sectionName: web
+  hostnames:
+    - {{ $fqdn | quote }}
+  rules:
+    # Standard Non-SSL Paths
+    - matches:
+        - path: { type: PathPrefix, value: /pub }
+        - path: { type: PathPrefix, value: /rhn/kickstart/DownloadFile }
+        - path: { type: PathPrefix, value: /rhn/common/DownloadFile }
+        - path: { type: PathPrefix, value: /rhn/rpc/api }
+        - path: { type: PathPrefix, value: /rpc/api }
+        - path: { type: PathPrefix, value: /rhn/errors }
+        - path: { type: PathPrefix, value: /rhn/ty/TinyUrl }
+        - path: { type: PathPrefix, value: /rhn/websocket }
+        - path: { type: PathPrefix, value: /rhn/metrics }
+        - path: { type: PathPrefix, value: /cobbler_api }
+        - path: { type: PathPrefix, value: /cobbler }
+        - path: { type: PathPrefix, value: /cblr }
+        - path: { type: PathPrefix, value: /httpboot }
+        - path: { type: PathPrefix, value: /images }
+        - path: { type: PathPrefix, value: /os-images }
+        - path: { type: PathPrefix, value: /tftp }
+        - path: { type: PathPrefix, value: /docs }
+      backendRefs:
+        - name: web
+          port: 80
+
+    {{- if ne .Values.enableMonitoring false }}
+    # Node exporter
+    - matches:
+        - path: { type: PathPrefix, value: /node-exporter }
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path: { type: ReplacePrefixMatch, replacePrefixMatch: / }
+      backendRefs:
+        - name: tomcat
+          port: 9100
+
+    # Tomcat Monitoring JMX
+    - matches:
+        - path: { type: PathPrefix, value: /tomcat-jmx }
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path: { type: ReplacePrefixMatch, replacePrefixMatch: / }
+      backendRefs:
+        - name: tomcat
+          port: 5557
+    
+    # Taskomatic Monitoring Exporter
+    - matches:
+        - path: { type: PathPrefix, value: /tasko-exporter }
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path: { type: ReplacePrefixMatch, replacePrefixMatch: / }
+      backendRefs:
+        - name: taskomatic
+          port: 9800
+    
+    # Taskomatic Monitoring JMX
+    - matches:
+        - path: { type: PathPrefix, value: /tasko-jmx }
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path: { type: ReplacePrefixMatch, replacePrefixMatch: / }
+      backendRefs:
+        - name: taskomatic
+          port: 5556
+    {{- end }}
+    {{- if .Values.saline.enable }}
+    - matches:
+        - path: { type: PathPrefix, value: /saline }
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path: { type: ReplacePrefixMatch, replacePrefixMatch: / }
+      backendRefs:
+        - name: saline
+          port: 8216
+    {{- end }}
+    {{- end }}

--- a/containers/server-helm/templates/setup-job.yaml
+++ b/containers/server-helm/templates/setup-job.yaml
@@ -92,6 +92,10 @@ spec:
                   key: fqdn
                   name: uyuni-config
                   optional: false
+{{- if .Values.exposeJavaDebug }}
+            - name: DEBUG_JAVA
+              value: "true"
+{{- end }}
 {{- if .Values.registrySecret }}
             - name: SCC_USER
               valueFrom:

--- a/containers/server-helm/templates/tcp-routes.yaml
+++ b/containers/server-helm/templates/tcp-routes.yaml
@@ -1,0 +1,102 @@
+{{- if .Values.gateway.enable }}
+{{- $gatewayName := default .Values.gateway.name "uyuni-gateway" -}}
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: salt-publish
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    app.kubernetes.io/part-of: uyuni
+spec:
+  parentRefs:
+  - name: {{ $gatewayName }}
+    sectionName: salt-publish
+  rules:
+    - backendRefs:
+      - name: salt
+        port: 4505
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: salt-request
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    app.kubernetes.io/part-of: uyuni
+spec:
+  parentRefs:
+  - name: {{ $gatewayName }}
+    sectionName: salt-request
+  rules:
+    - backendRefs:
+      - name: salt
+        port: 4506
+{{- if .Values.db.enable }}
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: reportdb-pgsql
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    app.kubernetes.io/part-of: uyuni
+spec:
+  parentRefs:
+  - name: {{ $gatewayName }}
+    sectionName: reportdb-pgsql
+  rules:
+    - backendRefs:
+      - name: reportdb
+        port: 5432
+{{- end }}
+{{- if .Values.exposeJavaDebug }}
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: tasko-debug
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    app.kubernetes.io/part-of: uyuni
+spec:
+  parentRefs:
+  - name: {{ $gatewayName }}
+    sectionName: tasko-debug
+  rules:
+    - backendRefs:
+      - name: taskomatic
+        port: 8001
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: search-debug
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    app.kubernetes.io/part-of: uyuni
+spec:
+  parentRefs:
+  - name: {{ $gatewayName }}
+    sectionName: search-debug
+  rules:
+    - backendRefs:
+      - name: search
+        port: 8002
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: tomcat-debug
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    app.kubernetes.io/part-of: uyuni
+spec:
+  parentRefs:
+  - name: {{ $gatewayName }}
+    sectionName: tomcat-debug
+  rules:
+    - backendRefs:
+      - name: tomcat
+        port: 8003
+{{- end }}
+{{- end }}

--- a/containers/server-helm/templates/traefik-routes.yaml
+++ b/containers/server-helm/templates/traefik-routes.yaml
@@ -1,4 +1,4 @@
-{{- if eq ((.Values.ingress).type) "traefik" }}
+{{- if and (not .Values.gateway.enable) (eq ((.Values.ingress).type) "traefik") }}
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
@@ -12,12 +12,30 @@ spec:
     permanent: true
 ---
 apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: uyuni-strip-prefixes
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/part-of: uyuni
+spec:
+  stripPrefix:
+    prefixes:
+      - /node-exporter
+      - /tasko-exporter
+      - /tasko-jmx
+      - /tomcat-jmx
+      - /saline
+---
+apiVersion: traefik.io/v1alpha1
 kind: IngressRouteTCP
 metadata:
   name: reportdb-pgsql-route
   namespace: "{{ .Release.Namespace }}"
   labels:
     app.kubernetes.io/part-of: uyuni
+  annotations:
+    kubernetes.io/ingress.class: {{ .Values.ingress.class }}
 spec:
   entryPoints:
     - reportdb-pgsql
@@ -34,6 +52,8 @@ metadata:
   namespace: "{{ .Release.Namespace }}"
   labels:
     app.kubernetes.io/part-of: uyuni
+  annotations:
+    kubernetes.io/ingress.class: {{ .Values.ingress.class }}
 spec:
   entryPoints:
     - salt-publish
@@ -50,6 +70,8 @@ metadata:
   namespace: "{{ .Release.Namespace }}"
   labels:
     app.kubernetes.io/part-of: uyuni
+  annotations:
+    kubernetes.io/ingress.class: {{ .Values.ingress.class }}
 spec:
   entryPoints:
     - salt-request
@@ -66,6 +88,8 @@ metadata:
   namespace: "{{ .Release.Namespace }}"
   labels:
     app.kubernetes.io/part-of: uyuni
+  annotations:
+    kubernetes.io/ingress.class: {{ .Values.ingress.class }}
 spec:
   entryPoints:
     - cobbler
@@ -78,19 +102,20 @@ spec:
 apiVersion: traefik.io/v1alpha1
 kind: IngressRouteTCP
 metadata:
-  annotations: {}
+  name: node-xport-route
+  namespace: "{{ .Release.Namespace }}"
   labels:
     app.kubernetes.io/part-of: uyuni
-  name: web-http-route
-  namespace: "{{ .Release.Namespace }}"
+  annotations:
+    kubernetes.io/ingress.class: {{ .Values.ingress.class }}
 spec:
   entryPoints:
-    - web-http
+    - node-xport
   routes:
     - match: HostSNI(`*`)
       services:
-        - name: web
-          port: 80
+      - name: tomcat
+        port: 9100
 {{- if ne .Values.enableMonitoring false }}
 ---
 apiVersion: traefik.io/v1alpha1
@@ -100,6 +125,8 @@ metadata:
   namespace: "{{ .Release.Namespace }}"
   labels:
     app.kubernetes.io/part-of: uyuni
+  annotations:
+    kubernetes.io/ingress.class: {{ .Values.ingress.class }}
 spec:
   entryPoints:
     - db-xport
@@ -116,6 +143,8 @@ metadata:
   namespace: "{{ .Release.Namespace }}"
   labels:
     app.kubernetes.io/part-of: uyuni
+  annotations:
+    kubernetes.io/ingress.class: {{ .Values.ingress.class }}
 spec:
   entryPoints:
     - tasko-jmx
@@ -132,6 +161,8 @@ metadata:
   namespace: "{{ .Release.Namespace }}"
   labels:
     app.kubernetes.io/part-of: uyuni
+  annotations:
+    kubernetes.io/ingress.class: {{ .Values.ingress.class }}
 spec:
   entryPoints:
     - tomcat-jmx
@@ -150,6 +181,8 @@ metadata:
   namespace: "{{ .Release.Namespace }}"
   labels:
     app.kubernetes.io/part-of: uyuni
+  annotations:
+    kubernetes.io/ingress.class: {{ .Values.ingress.class }}
 spec:
   entryPoints:
     - tomcat-debug
@@ -166,6 +199,8 @@ metadata:
   namespace: "{{ .Release.Namespace }}"
   labels:
     app.kubernetes.io/part-of: uyuni
+  annotations:
+    kubernetes.io/ingress.class: {{ .Values.ingress.class }}
 spec:
   entryPoints:
     - search-debug
@@ -182,6 +217,8 @@ metadata:
   namespace: "{{ .Release.Namespace }}"
   labels:
     app.kubernetes.io/part-of: uyuni
+  annotations:
+    kubernetes.io/ingress.class: {{ .Values.ingress.class }}
 spec:
   entryPoints:
     - tasko-debug

--- a/containers/server-helm/test.sh
+++ b/containers/server-helm/test.sh
@@ -11,3 +11,9 @@ helm template . --set global.fqdn=test.local --set hubAPI.enable=true --set coco
          kubeconform -summary -strict \
            -schema-location default \
            -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
+
+# Check the API Gateway resources
+helm template . --set global.fqdn=test.local --set hubAPI.enable=true --set coco.replicas=3 --set saline.enable=true --set gateway.enable=true --set gateway.class=gw | \
+         kubeconform -summary -strict \
+           -schema-location default \
+           -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'

--- a/containers/server-helm/tests/README.md
+++ b/containers/server-helm/tests/README.md
@@ -1,0 +1,2 @@
+The unit tests in this folder are written using helm-unittest.
+See https://github.com/helm-unittest/helm-unittest/blob/main/DOCUMENT.md for its reference.

--- a/containers/server-helm/tests/gateway_tests.yaml
+++ b/containers/server-helm/tests/gateway_tests.yaml
@@ -1,0 +1,164 @@
+suite: test ingress providers
+templates:
+  - ingress.yaml
+  - traefik-routes.yaml
+  - gateway.yaml
+  - routes.yaml
+  - tcp-routes.yaml
+tests:
+
+  - it: should not enable gateway resources by default
+    set:
+      global.fqdn: uyuni.example.com
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: gateway.yaml
+      
+      - hasDocuments:
+          count: 0
+        template: routes.yaml
+      
+      - hasDocuments:
+          count: 0
+        template: tcp-routes.yaml
+
+  - it: should switch to gateway resources when enabled
+    set:
+      global.fqdn: uyuni.example.com
+      gateway:
+        enable: true
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: gateway.yaml
+      
+      - hasDocuments:
+          count: 3
+        template: routes.yaml
+      
+      - hasDocuments:
+          count: 3
+        templates: tcp-routes.yaml
+
+      - hasDocuments:
+          count: 0
+        template: ingress.yaml
+
+      - hasDocument:
+          count: 0
+        template: traefik-routes.yaml
+  
+  - it: should use the given Gateway if a name is set
+    set:
+      global.fqdn: uyuni.example.com
+      gateway:
+        enable: true
+        name: "test-gw"
+        exposeJavaDebug: true
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: gateway.yaml
+
+      - hasDocument:
+          count: 3
+        template: routes.yaml
+        documentSelector:
+          path: spec.parentRefs[?(@.name=="test-gw")].name
+          value: test-gw
+
+      - hasDocument:
+          count: 6
+        template: tcp-routes.yaml
+        documentSelector:
+          path: spec.parentRefs[?(@.name=="test-gw")].name
+          value: test-gw
+  
+  - it: should create all HTTPRoutes and TCPRoutes
+    set:
+      global.fqdn: uyuni.example.com
+      gateway:
+        enable: true
+        exposeJavaDebug: true
+      release:
+        namespace: myns
+    asserts:
+      - containsDocument:
+          kind: Gateway
+          apiVersion: gateway.networking.k8s.io/v1
+          name: uyuni-gateway
+          namespace: myns
+        template: gateway.yaml
+      
+      - containsDocument:
+          kind: HTTPRoute
+          apiVersion: gateway.networking.k8s.io/v1
+          name: uyuni-ssl-redirect
+          namespace: myns
+          any: true
+        template: routes.yaml
+      
+      - containsDocument:
+          kind: HTTPRoute
+          apiVersion: gateway.networking.k8s.io/v1
+          name: uyuni-https-routes
+          namespace: myns
+          any: true
+        template: routes.yaml
+      
+      - containsDocument:
+          kind: HTTPRoute
+          apiVersion: gateway.networking.k8s.io/v1
+          name: uyuni-nossl-routes
+          namespace: myns
+          any: true
+        template: routes.yaml
+      
+      - containsDocument:
+          kind: TCPRoute
+          apiVersion: gateway.networking.k8s.io/v1alpha2
+          name: salt-publish
+          namespace: myns
+          any: true
+        template: tcp-routes.yaml
+      
+      - containsDocument:
+          kind: TCPRoute
+          apiVersion: gateway.networking.k8s.io/v1alpha2
+          name: salt-request
+          namespace: myns
+          any: true
+        template: tcp-routes.yaml
+      
+      - containsDocument:
+          kind: TCPRoute
+          apiVersion: gateway.networking.k8s.io/v1alpha2
+          name: reportdb-pgsql
+          namespace: myns
+          any: true
+        template: tcp-routes.yaml
+      
+      - containsDocument:
+          kind: TCPRoute
+          apiVersion: gateway.networking.k8s.io/v1alpha2
+          name: tasko-debug
+          namespace: myns
+          any: true
+        template: tcp-routes.yaml
+      
+      - containsDocument:
+          kind: TCPRoute
+          apiVersion: gateway.networking.k8s.io/v1alpha2
+          name: search-debug
+          namespace: myns
+          any: true
+        template: tcp-routes.yaml
+      
+      - containsDocument:
+          kind: TCPRoute
+          apiVersion: gateway.networking.k8s.io/v1alpha2
+          name: tomcat-debug
+          namespace: myns
+          any: true
+        template: tcp-routes.yaml

--- a/containers/server-helm/tests/ingress_test.yaml
+++ b/containers/server-helm/tests/ingress_test.yaml
@@ -2,61 +2,13 @@ suite: test ingress providers
 templates:
   - ingress.yaml
 tests:
-  - it: should use traefik annotations on the SSL ingress
-    set:
-      global.fqdn: uyuni.example.com
-      ingress:
-        type: "traefik"
-    documentSelector:
-      path: metadata.name
-      value: uyuni-ingress-ssl
-    asserts:
-      - equal:
-          path: metadata.annotations["traefik.ingress.kubernetes.io/router.tls"]
-          value: "true"
-
-  - it: should verify TLS is disabled on the No-SSL ingress
-    set:
-      global.fqdn: uyuni.example.com
-      ingress:
-        type: "traefik"
-    documentSelector:
-      path: metadata.name
-      value: uyuni-ingress-nossl
-    asserts:
-      - equal:
-          path: metadata.annotations["traefik.ingress.kubernetes.io/router.tls"]
-          value: "false"
-
-  - it: should verify redirect middleware on the redirect ingress
-    set:
-      global.fqdn: uyuni.example.com
-      ingress:
-        type: "traefik"
-    documentSelector:
-      path: metadata.name
-      value: uyuni-ingress-ssl-redirect
-    asserts:
-      - equal:
-          path: metadata.annotations["traefik.ingress.kubernetes.io/router.middlewares"]
-          value: "default-uyuni-https-redirect@kubernetescrd"
-
-  - it: should switch to nginx annotations
-    set:
-      global.fqdn: uyuni.example.com
-      ingress:
-        type: "nginx"
-    asserts:
-      - equal:
-          path: metadata.annotations["nginx.ingress.kubernetes.io/ssl-redirect"]
-          value: "false"
-    documentSelector:
-      path: metadata.name
-      value: uyuni-ingress-nossl
-
   - it: should render custom annotations for all ingress types
     set:
       global.fqdn: uyuni.example.com
+      saline:
+        enable: true
+      hubAPI:
+        enable: true
       ingress:
         type: "traefik"
         annotations:
@@ -64,9 +16,13 @@ tests:
             cert-manager.io/cluster-issuer: "uyuni-issuer"
             external-dns.alpha.kubernetes.io/ttl: "60"
           sslRedirect:
-            traefik.ingress.kubernetes.io/router.priority: "100"
+            example.com/foo: "100"
           nossl:
             custom.annotation/test: "nossl-only"
+          saline:
+            custom.annotation/test: "saline-only"
+          hub:
+            custom.annotation/test: "hub-only"
     asserts:
       # Test SSL Ingress custom annotations
       - equal:
@@ -84,7 +40,7 @@ tests:
 
       # Test SSL Redirect Ingress custom annotations
       - equal:
-          path: metadata.annotations["traefik.ingress.kubernetes.io/router.priority"]
+          path: metadata.annotations["example.com/foo"]
           value: "100"
         documentSelector:
           path: metadata.name
@@ -98,9 +54,29 @@ tests:
           path: metadata.name
           value: uyuni-ingress-nossl
 
+      # Test Saline ingress custom annotations
+      - equal:
+          path: metadata.annotations["custom.annotation/test"]
+          value: "saline-only"
+        documentSelector:
+          path: metadata.name
+          value: saline-ingress-ssl
+
+      # Test Hub ingress custom annotations
+      - equal:
+          path: metadata.annotations["custom.annotation/test"]
+          value: "hub-only"
+        documentSelector:
+          path: metadata.name
+          value: hubapi-ingress-ssl
+
   - it: should render the ingress class name when provided
     set:
       global.fqdn: uyuni.example.com
+      saline:
+        enable: true
+      hubAPI:
+        enable: true
       ingress:
         class: "nginx-internal"
     asserts:
@@ -115,4 +91,296 @@ tests:
           value: "nginx-internal"
         documentSelector:
           path: metadata.name
+          value: saline-ingress-ssl
+      - equal:
+          path: spec.ingressClassName
+          value: "nginx-internal"
+        documentSelector:
+          path: metadata.name
+          value: hubapi-ingress-ssl
+      - equal:
+          path: spec.ingressClassName
+          value: "nginx-internal"
+        documentSelector:
+          path: metadata.name
+          value: uyuni-ingress-ssl-redirect
+      - equal:
+          path: spec.ingressClassName
+          value: "nginx-internal"
+        documentSelector:
+          path: metadata.name
           value: uyuni-ingress-nossl
+
+  - it: should render traefik annotations
+    release:
+      namespace: myns
+    set:
+      global.fqdn: uyuni.example.com
+      saline:
+        enable: true
+      hubAPI:
+        enable: true
+      ingress:
+        type: "traefik"
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            traefik.ingress.kubernetes.io/router.tls: "true"
+            traefik.ingress.kubernetes.io/router.tls.domains.n.main: "uyuni.example.com"
+            traefik.ingress.kubernetes.io/router.entrypoints: "websecure"
+            traefik.ingress.kubernetes.io/router.priority: "1"
+            traefik.ingress.kubernetes.io/router.middlewares: "myns-uyuni-strip-prefixes@kubernetescrd"
+        documentSelector:
+          path: metadata.name
+          value: "uyuni-ingress-ssl"
+
+      - isSubset:
+          path: metadata.annotations
+          content:
+            traefik.ingress.kubernetes.io/router.tls: "true"
+            traefik.ingress.kubernetes.io/router.tls.domains.n.main: "uyuni.example.com"
+            traefik.ingress.kubernetes.io/router.entrypoints: "websecure"
+            traefik.ingress.kubernetes.io/router.priority: "100"
+            traefik.ingress.kubernetes.io/router.middlewares: "myns-uyuni-strip-prefixes@kubernetescrd"
+        documentSelector:
+          path: metadata.name
+          value: "saline-ingress-ssl"
+
+      - isSubset:
+          path: metadata.annotations
+          content:
+            traefik.ingress.kubernetes.io/router.tls: "true"
+            traefik.ingress.kubernetes.io/router.tls.domains.n.main: "uyuni.example.com"
+            traefik.ingress.kubernetes.io/router.entrypoints: "websecure"
+            traefik.ingress.kubernetes.io/router.priority: "100"
+            traefik.ingress.kubernetes.io/router.middlewares: "myns-uyuni-strip-prefixes@kubernetescrd"
+        documentSelector:
+          path: metadata.name
+          value: "hubapi-ingress-ssl"
+      
+      - isSubset:
+          path: metadata.annotations
+          content:
+            traefik.ingress.kubernetes.io/router.entrypoints: "web"
+            traefik.ingress.kubernetes.io/router.priority: "1"
+            traefik.ingress.kubernetes.io/router.middlewares: "myns-uyuni-https-redirect@kubernetescrd"
+        documentSelector:
+          path: metadata.name
+          value: "uyuni-ingress-ssl-redirect"
+
+      - isSubset:
+          path: metadata.annotations
+          content:
+            traefik.ingress.kubernetes.io/router.tls: "false"
+            traefik.ingress.kubernetes.io/router.entrypoints: "web"
+            traefik.ingress.kubernetes.io/router.priority: "100"
+            traefik.ingress.kubernetes.io/router.middlewares: "myns-uyuni-strip-prefixes@kubernetescrd"
+        documentSelector:
+          path: metadata.name
+          value: "uyuni-ingress-nossl"
+
+  - it: should contain the monitoring paths by default
+    release:
+      namespace: myns
+    set:
+      global.fqdn: uyuni.example.com
+    asserts:
+      - isSubset:
+          path: spec.rules[?(@.host=="uyuni.example.com")].http.paths[?(@.path=="/node-exporter")]
+          any: true
+          content:
+            pathType: Prefix
+            backend:
+              service:
+                name: tomcat
+                port:
+                  number: 9100
+        documentSelector:
+          path: metadata.name
+          value: "uyuni-ingress-nossl"
+
+      - isSubset:
+          path: spec.rules[?(@.host=="uyuni.example.com")].http.paths[?(@.path=="/tasko-exporter")]
+          content:
+            pathType: Prefix
+            backend:
+              service:
+                name: taskomatic
+                port:
+                  number: 9800
+        documentSelector:
+          path: metadata.name
+          value: "uyuni-ingress-nossl"
+
+      - isSubset:
+          path: spec.rules[?(@.host=="uyuni.example.com")].http.paths[?(@.path=="/tasko-jmx")]
+          content:
+            pathType: Prefix
+            backend:
+              service:
+                name: taskomatic
+                port:
+                  number: 5556
+        documentSelector:
+          path: metadata.name
+          value: "uyuni-ingress-nossl"
+
+      - isSubset:
+          path: spec.rules[?(@.host=="uyuni.example.com")].http.paths[?(@.path=="/tomcat-jmx")]
+          content:
+            pathType: Prefix
+            backend:
+              service:
+                name: tomcat
+                port:
+                  number: 5557
+        documentSelector:
+          path: metadata.name
+          value: "uyuni-ingress-nossl"
+
+  - it: should not contain the monitoring paths when disabled
+    release:
+      namespace: myns
+    set:
+      global.fqdn: uyuni.example.com
+      enableMonitoring: false
+
+    asserts:
+      - notExists:
+          path: spec.rules[?(@.host=="uyuni.example.com")].http.paths[?(@.path=="/node-exporter")]
+        documentSelector:
+          path: metadata.name
+          value: "uyuni-ingress-nossl"
+
+      - notExists:
+          path: spec.rules[?(@.host=="uyuni.example.com")].http.paths[?(@.path=="/tasko-exporter")]
+        documentSelector:
+          path: metadata.name
+          value: "uyuni-ingress-nossl"
+
+      - notExists:
+          path: spec.rules[?(@.host=="uyuni.example.com")].http.paths[?(@.path=="/tasko-jmx")]
+        documentSelector:
+          path: metadata.name
+          value: "uyuni-ingress-nossl"
+
+      - notExists:
+          path: spec.rules[?(@.host=="uyuni.example.com")].http.paths[?(@.path=="/tomcat-jmx")]
+        documentSelector:
+          path: metadata.name
+          value: "uyuni-ingress-nossl"
+
+  - it: should contain the saline paths when enabled
+    release:
+      namespace: myns
+    set:
+      global.fqdn: uyuni.example.com
+      saline:
+        enable: true
+    asserts:
+      - isSubset:
+          path: spec.rules[?(@.host=="uyuni.example.com")].http.paths[?(@.path=="/saline")]
+          any: true
+          content:
+            pathType: Prefix
+            backend:
+              service:
+                name: saline
+                port:
+                  number: 8216
+        documentSelector:
+          path: metadata.name
+          value: "uyuni-ingress-nossl"
+
+      - isSubset:
+          path: spec.rules[?(@.host=="uyuni.example.com")].http.paths[?(@.path=="/saline")]
+          any: true
+          content:
+            pathType: Prefix
+            backend:
+              service:
+                name: saline
+                port:
+                  number: 8216
+        documentSelector:
+          path: metadata.name
+          value: "saline-ingress-ssl"
+
+  - it: should not contain the saline paths by default
+    release:
+      namespace: myns
+    set:
+      global.fqdn: uyuni.example.com
+
+    asserts:
+      - notExists:
+          path: spec.rules[?(@.host=="uyuni.example.com")].http.paths[?(@.path=="/saline")]
+        documentSelector:
+          path: metadata.name
+          value: "uyuni-ingress-nossl"
+
+      - hasDocuments:
+          count: 0
+        template: ingress.yaml
+        documentSelector:
+          path: metadata.name
+          value: "saline-ingress-ssl"
+          skipEmptyTemplates: true
+
+  - it: should contain the hub paths when enabled
+    release:
+      namespace: myns
+    set:
+      global.fqdn: uyuni.example.com
+      hubAPI:
+        enable: true
+    asserts:
+      - isSubset:
+          path: spec.rules[?(@.host=="uyuni.example.com")].http.paths[?(@.path=="/hub/rpc/api")]
+          any: true
+          content:
+            pathType: Prefix
+            backend:
+              service:
+                name: hub-xmlrpc
+                port:
+                  number: 2830
+        documentSelector:
+          path: metadata.name
+          value: "uyuni-ingress-ssl-redirect"
+
+      - isSubset:
+          path: spec.rules[?(@.host=="uyuni.example.com")].http.paths[?(@.path=="/hub/rpc/api")]
+          any: true
+          content:
+            pathType: Prefix
+            backend:
+              service:
+                name: hub-xmlrpc
+                port:
+                  number: 2830
+        documentSelector:
+          path: metadata.name
+          value: "hubapi-ingress-ssl"
+
+  - it: should not contain the hub paths by default
+    release:
+      namespace: myns
+    set:
+      global.fqdn: uyuni.example.com
+
+    asserts:
+      - notExists:
+          path: spec.rules[?(@.host=="uyuni.example.com")].http.paths[?(@.path=="/hub/rpc/api")]
+        documentSelector:
+          path: metadata.name
+          value: "uyuni-ingress-ssl-redirect"
+
+      - hasDocuments:
+          count: 0
+        template: ingress.yaml
+        documentSelector:
+          path: metadata.name
+          value: "hubapi-ingress-ssl"
+          skipEmptyTemplates: true

--- a/containers/server-helm/tests/traefik-routes.yaml
+++ b/containers/server-helm/tests/traefik-routes.yaml
@@ -1,6 +1,6 @@
 suite: test ingress providers
 templates:
-  - k3s-ingress-routes.yaml
+  - traefik-routes.yaml
 tests:
   - it: should route database exporters port with traefik ingress and monitoring enabled
     set:

--- a/containers/server-helm/values.schema.json
+++ b/containers/server-helm/values.schema.json
@@ -150,13 +150,14 @@
       "properties": {
         "type": {
           "type": "string",
-          "description": "Type of ingress used (e.g., nginx, traefik)",
+          "description": "Type of ingress used (supported values: traefik, '')",
+          "enum": ["traefik", ""],
           "default": "traefik"
         },
         "class": {
           "type": "string",
-          "description": "Ingress class name",
-          "default": ""
+          "description": "Name of the ingress class to use. This value will be used in traefik routes annotations.",
+          "default": "traefik"
         },
         "annotations": {
           "type": "object",
@@ -164,8 +165,39 @@
           "properties": {
             "ssl": { "type": "object" },
             "sslRedirect": { "type": "object" },
-            "nossl": { "type": "object" }
+            "nossl": { "type": "object" },
+            "saline": { "type": "object" },
+            "hub": { "type": "object" }
           }
+        }
+      }
+    },
+    "gateway": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the gateway to use. An empty string value means that a gateway will be deployed and named uyuni-gateway.",
+          "default": ""
+        },
+        "class": {
+          "type": "string",
+          "description": "Name of the gateway class to use. For rke2 with traefik, it is likely to be 'traefik'.",
+          "default": ""
+        },
+        "listeners": {
+            "type": "object",
+            "description": "Gateway listeners configuration",
+            "properties": {
+                "http": {
+                    "$ref": "#/definitions/listener",
+                    "description": "Configuration of the HTTP listener. Defaults are adjusted to traefik on rke2"
+                },
+                "https": {
+                    "$ref": "#/definitions/listener",
+                    "description": "Configuration of the HTTPS listener. Defaults are adjusted to traefik on rke2"
+                }
+            }
         }
       }
     },
@@ -289,6 +321,19 @@
           "description": "selector to set on the volume claim"
         }
       }
+    },
+    "listener": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string",
+                "description": "the name of the listener"
+            },
+            "port": {
+                "type": "integer",
+                "description": "the port of the listener"
+            }
+        }
     }
   }
 }

--- a/containers/server-helm/values.yaml
+++ b/containers/server-helm/values.yaml
@@ -727,7 +727,7 @@ volumes:
     ## selector is rendered with toYAML and can be used to bind to a specific PV.
     selector:
 
-## servicesAnnotations are annotations to set on both TCP and UDP services.
+## servicesAnnotations are annotations to set on all services.
 ## This can be useful to share the same IP when using metallb
 ##
 servicesAnnotations:
@@ -747,8 +747,11 @@ ingress:
   ##
   type: "traefik"
   ## Specify the ingress class name to use. Empty, means that the default one will be used.
+  ## If using the traefik end points and TCP routers, this value needs to match Traefik's
+  ## --providers.kubernetescrd.ingressclass parameter's value.
+  ## On rke2 this is likely to be "traefik". On K3S it is likely to be ""
   ##
-  class: ""
+  class: "traefik"
   ## annotations can be used to set custom annotations on the created ingress rules.
   ## This can be used to configure another ingress than the ones already wired with the ingress.type.
   ## The ssl annotations can also be used to set a cert-manager issuer like:
@@ -760,6 +763,32 @@ ingress:
   #  ssl:
   #  sslRedirect:
   #  nossl:
+  #  saline:
+  #  hub:
+
+# Gateway configures the Gateway API.
+gateway:
+  ## If enabled, Gateway API 1.4 resources will be deployed instead of the ingress ones.
+  ## Note that TCPRoute is used and is still in alpha2 stage.
+  enable: false
+
+  ## Name of the gateway class to use. For rke2 with traefik, it is likely to be "traefik".
+  class: ""
+
+  ## Name of the gateway to use. An empty string value means that a gateway will be deployed and named uyuni-gateway.
+  name: ""
+
+  listeners:
+    http:
+      ## Name to set for the gateway http listener. The default is adjusted for traefik on rke2
+      name: "web"
+      ## Port to set for the gateway http listener. The default is adjusted for traefik on rke2
+      port: 8000
+    https:
+      ## Name to set for the gateway https listener. The default is adjusted for traefik on rke2
+      name: "websecure"
+      ## Port to set for the gateway https listener. The default is adjusted for traefik on rke2
+      port: 8443
 
 ## TFTP server configuration
 ##

--- a/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
+++ b/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
@@ -132,6 +132,29 @@ ProxyPassReverse "/hub/rpc/api" "http://uyuni-hub-xmlrpc-0:2830/hub/rpc/api"
   ErrorDocument 502 "Hub XML-RPC API  server is not available"
 </Location>
 
+ProxyPass "/node-exporter" "http://localhost:9100"
+ProxyPassReverse "/node-exporter" "http://localhost:9100"
+<Location /node-exporter>
+  ErrorDocument 502 "Node exporter is not available"
+</Location>
+
+ProxyPass "/tasko-exporter" "http://localhost:9800"
+ProxyPassReverse "/tasko-exporter" "http://localhost:9800"
+<Location /tasko-exporter>
+  ErrorDocument 502 "Taskomatic exporter is not available"
+</Location>
+
+ProxyPass "/tasko-jmx" "http://localhost:5556"
+ProxyPassReverse "/tasko-jmx" "http://localhost:5556"
+<Location /tasko-jmx>
+  ErrorDocument 502 "Taskomatic JMX exporter is not available"
+</Location>
+
+ProxyPass "/tomcat-jmx" "http://localhost:5557"
+ProxyPassReverse "/tomcat-jmx" "http://localhost:5557"
+<Location /tomcat-jmx>
+  ErrorDocument 502 "Tomcat JMX exporter is not available"
+</Location>
 
 # mod_xsendfile configuration
 XSendFile on

--- a/spacewalk/config/spacewalk-config.changes.cbosdo.server-selinux
+++ b/spacewalk/config/spacewalk-config.changes.cbosdo.server-selinux
@@ -1,0 +1,1 @@
+- Proxy the exporters using Apache


### PR DESCRIPTION
## What does this PR change?

Traefik takes the shorter ingress rules first. So `/` is a catch all and is used for the no-ssl paths too. Adding priorities allows tuning this.

Traefik also needs the ingress class to be set in an annotation on the TCP routes. Take the one from the values for this. However, the default value has to be the empty string and would only work for k3s since rke2 sets it to `traefik`.

While at it, replace k3s with traefik in the file names.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/29503

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
